### PR TITLE
fix: update pronunciation of rspack

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -18,5 +18,5 @@
   ],
   "caseSensitive": true,
   "allowCompoundWords": true,
-  "ignoreWords": ["antd", "ɑrspæk", "Shenzhen"]
+  "ignoreWords": ["antd", "ɑrespæk", "Shenzhen"]
 }

--- a/docs/en/guide/introduction.mdx
+++ b/docs/en/guide/introduction.mdx
@@ -8,7 +8,7 @@ import rspackAudio from '../../public/rspack.mp3';
 # Introduction
 
 <div>
-  <span>Rspack (pronounced as `/'ɑrspæk/`, </span>
+  <span>Rspack (pronounced as `/'ɑrespæk/`, </span>
   <button
     style={{
       border: 'none',

--- a/docs/zh/guide/introduction.mdx
+++ b/docs/zh/guide/introduction.mdx
@@ -8,7 +8,7 @@ import rspackAudio from '../../public/rspack.mp3';
 # 介绍
 
 <div>
-  <span>Rspack（读音为 `/'ɑrspæk/`,</span>
+  <span>Rspack（读音为 `/'ɑrespæk/`,</span>
   <button
     style={{
       border: 'none',


### PR DESCRIPTION
The pronunciation of rspack based on the audio should be `/'ɑrespæk/` instead of `/'ɑrspæk/`. The english character "s" should be pronounced as `/es/` (see dictionary [here](https://www.oxfordlearnersdictionaries.com/definition/english/s_1?q=s)), and `/'ɑrspæk/` will be pronounced easily to `ér si pài ke` instead of the actual `ér ái si pài ke`