### PR TITLE
docs: fix plugin typo & invalid link

### DIFF
--- a/docs/en/config/plugins.mdx
+++ b/docs/en/config/plugins.mdx
@@ -13,7 +13,7 @@ interface RspackPluginInstance {
 }
 ```
 
-Among them, the interface provided on Compiler can refer to (plugin api)[../api/plugin-api].
+Among them, the interface provided on Compiler can refer to [plugin api](../api/plugin-api).
 
 usage:
 
@@ -25,7 +25,7 @@ class CustomPlugin {
 }
 
 module.exports = {
-  plugin: [new CustomPlugin()],
+  plugins: [new CustomPlugin()],
 };
 ```
 
@@ -43,6 +43,6 @@ function customPlugin(compiler) {
 }
 
 module.exports = {
-  plugin: [customPlugin],
+  plugins: [customPlugin],
 };
 ```

--- a/docs/zh/config/plugins.mdx
+++ b/docs/zh/config/plugins.mdx
@@ -13,7 +13,7 @@ interface RspackPluginInstance {
 }
 ```
 
-其中，Compiler 上提供的接口可以参考 (plugin api)[../api/plugin-api]。
+其中，Compiler 上提供的接口可以参考 [plugin api](../api/plugin-api)。
 
 用法：
 
@@ -25,7 +25,7 @@ class CustomPlugin {
 }
 
 module.exports = {
-  plugin: [new CustomPlugin()],
+  plugins: [new CustomPlugin()],
 };
 ```
 
@@ -43,6 +43,6 @@ function customPlugin(compiler) {
 }
 
 module.exports = {
-  plugin: [customPlugin],
+  plugins: [customPlugin],
 };
 ```


### PR DESCRIPTION
* fix plugin typo
* fix plugin invalid link