### PR TITLE
chore: remove ** in api-modules subtitles to allow rightside click enabled

### DIFF
--- a/docs/en/api/modules.mdx
+++ b/docs/en/api/modules.mdx
@@ -6,7 +6,7 @@ import WebpackLicense from '../../../components/webpack-license';
 
 While Rspack supports multiple module syntaxes, we recommend following a single syntax for consistency and to avoid odd behaviors/bugs.
 
-### ES6(Recommended)
+### ES6 (Recommended)
 
 Rspack support ES6 module syntax natively, you can use static `import`、 `export` and `import()` syntax.
 
@@ -34,11 +34,11 @@ If mode is set to 'lazy', the underlying modules will be loaded asynchronously.
 
 ## Module Variables
 
-### module.hot(webpack-specific)
+### module.hot (webpack-specific)
 
 Indicates whether or not Hot Module Replacement is enabled and provides an interface to the process. See the [HMR API page](/api/hmr) for details.
 
-### import.meta.webpackHot(webpack-specific)
+### import.meta.webpackHot (webpack-specific)
 
 An alias for `module.hot`, however `import.meta.webpackHot` can be used in strict ESM while module.hot can't.
 
@@ -63,14 +63,14 @@ require('file.js?test');
 __resourceQuery === '?test';
 ```
 
-### **webpack_modules**(webpack-specific)
+### webpack_modules (webpack-specific)
 
 Access to the internal object of all modules.
 
-### **webpack_hash**(webpack-specific)
+### webpack_hash (webpack-specific)
 
 It provides access to the hash of the compilation.
 
-### **webpack_public_path**(webpack-specific)
+### webpack_public_path (webpack-specific)
 
 Equals the configuration option's [`output.publicPath`](/config/output#outputpublicpath).

--- a/docs/zh/api/modules.mdx
+++ b/docs/zh/api/modules.mdx
@@ -6,7 +6,7 @@ import WebpackLicense from '../../../components/webpack-license';
 
 虽然 Rspack 支持多种模块语法，但我们建议遵循单一的语法，以保持一致性并避免 bug。
 
-### ES6(推荐)
+### ES6 (推荐)
 
 Rspack 原生支持 ES6 模块语法，可以使用静态的 `import`、`export` 和 `import()` 语法。
 
@@ -63,14 +63,14 @@ require('file.js?test');
 __resourceQuery === '?test';
 ```
 
-### **webpack_modules** (webpack 专用)
+### webpack_modules (webpack 专用)
 
 访问所有模块的内部对象。
 
-### **webpack_hash** (webpack 专用)
+### webpack_hash (webpack 专用)
 
 这个变量提供对编译过程中(compilation)的 hash 信息的访问。
 
-### **webpack_public_path** (webpack 专用)
+### webpack_public_path (webpack 专用)
 
 等于配置选项的 [output.publicPath](/config/output#outputpublicpath)。


### PR DESCRIPTION
When I try to find about `rspack` modules at [modules](https://www.rspack.dev/api/modules.html), I found that some subtitles only write `(webpack-specific)`.

Before changes:
![image](https://user-images.githubusercontent.com/10685039/226551401-d4ac872b-5ce4-41b6-8fa5-b08e75812fd9.png)

After changes:
![image](https://user-images.githubusercontent.com/10685039/226551700-47668de7-2540-4342-b9cb-692f7c83bc2a.png)

But it also have some experience problems on right-sides title list when titles are really close.