### PR TITLE
fix: incorrect file extension in language-support.mdx

### DIFF
--- a/docs/en/guide/language-support.mdx
+++ b/docs/en/guide/language-support.mdx
@@ -139,7 +139,7 @@ module.exports = {
 };
 ```
 
-The above configuration runs all `*.css` files through the [less-loader](https://github.com/webpack-contrib/less-loader) and passes the generated results to Rspack for CSS post-processing.
+The above configuration runs all `*.less` files through the [less-loader](https://github.com/webpack-contrib/less-loader) and passes the generated results to Rspack for CSS post-processing.
 
 ### Sass
 

--- a/docs/zh/guide/language-support.mdx
+++ b/docs/zh/guide/language-support.mdx
@@ -142,7 +142,7 @@ module.exports = {
 };
 ```
 
-上述配置会将所有 `*.css` 文件经过 [less-loader](https://github.com/webpack-contrib/less-loader) 处理，并将生成的结果交给 Rspack 完成 CSS 后续流程的处理。
+上述配置会将所有 `*.less` 文件经过 [less-loader](https://github.com/webpack-contrib/less-loader) 处理，并将生成的结果交给 Rspack 完成 CSS 后续流程的处理。
 
 ### Sass
 


### PR DESCRIPTION
### Less

Rspack 已经完成了对 [less-loader](https://github.com/webpack-contrib/less-loader) 的兼容，你可以这样配置：

```ts title="rspack.config.js"
module.exports = {
  module: {
    rules: [
      {
        test: /\.less$/,
        use: [
          {
            loader: 'less-loader',
            options: {
              // ...
            },
          },
        ],
        type: 'css',
      },
    ],
  },
};
```

上述配置会将所有 `*.css` 文件经过 [less-loader](https://github.com/webpack-contrib/less-loader) 处理，并将生成的结果交给 Rspack 完成 CSS 后续流程的处理。

`*.css` 应该改为 `*.less`
