### PR TITLE
docs: add output.crossOriginLoading config

### DIFF
--- a/docs/en/config/output.mdx
+++ b/docs/en/config/output.mdx
@@ -124,6 +124,44 @@ This option determines the name of the CSS file.
 
 This option determines the name of the non-initial CSS chunk file.
 
+## output.crossOriginLoading
+
+- **Type:** `false | 'anonymous' | 'use-credentials'`
+- **Default:** `false`
+
+The `crossOriginLoading` config allows you to set the [crossorigin attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin) for dynamically loaded chunks.
+
+If `target` is `'web'`, Rspack will dynamically create `<script>` and `<link>` tags to load asynchronous JavaScript and CSS resources. Rspack will add the `crossorigin` attribute to the `<script>` and `<link>` tags if the URLs of these resources are on other domains and `crossOriginLoading` is not `false`.
+
+### Optional values
+
+`crossOriginLoading` has the following optional values:
+
+- `false`: Do not set the [crossorigin attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin).
+- `'anonymous'`: Set `crossorigin` to `'anonymous'` to enable cross-origin without user credentials.
+- `'use-credentials'`: Set `crossorigin` to `'use-credentials'` enable cross-origin with user credentials.
+
+### Example
+
+For example, set `output.publicPath` to `https://example.com/` and `output.crossOriginLoading` to `'anonymous'`:
+
+```ts title="rspack.config.js"
+const path = require('path');
+
+module.exports = {
+  output: {
+    publicPath: 'https://example.com/',
+    crossOriginLoading: 'anonymous',
+  },
+};
+```
+
+When Rspack dynamically loads JavaScript resources, it will generate the following HTML:
+
+```html
+<script src="https://example.com/foo.js" crossorigin="anonymous"></script>
+```
+
 ## output.path
 
 - **Type:** `string`

--- a/docs/zh/config/output.mdx
+++ b/docs/zh/config/output.mdx
@@ -124,6 +124,44 @@ module.exports = {
 
 此选项决定了非初始（non-initial）CSS chunk 文件的名称。
 
+## output.crossOriginLoading
+
+- **类型：** `false | 'anonymous' | 'use-credentials'`
+- **默认值：** `false`
+
+通过 `crossOriginLoading` 配置项，你可以为动态加载的 chunks 设置 [crossorigin 属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin)。
+
+当 `target` 为 `'web'` 时，Rspack 会动态创建 `<script>` 和 `<link>` 标签来加载异步的 JavaScript 和 CSS 资源。如果这些资源的 URL 在其他域名下，且 `crossOriginLoading` 不为 `false`，那么 Rspack 会为 `<script>` 和 `<link>` 标签添加 `crossorigin` 属性。
+
+### 可选值
+
+`crossOriginLoading` 有以下可选值：
+
+- `false`: 不设置 [crossorigin 属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin)。
+- `'anonymous'`：将 `crossorigin` 设置为 `'anonymous'`，不包含用户凭据来跨域加载资源。
+- `'use-credentials'`：将 `crossorigin` 设置为 `'use-credentials'`，包含用户凭据来跨域加载资源。
+
+### 示例
+
+比如将 `output.publicPath` 设置为 `https://example.com/`，并将 `output.crossOriginLoading` 设置为 `'anonymous'`：
+
+```ts title="rspack.config.js"
+const path = require('path');
+
+module.exports = {
+  output: {
+    publicPath: 'https://example.com/',
+    crossOriginLoading: 'anonymous',
+  },
+};
+```
+
+当 Rspack 在加载异步的 JavaScript 资源时，会生成如下的 HTML：
+
+```html
+<script src="https://example.com/foo.js" crossorigin="anonymous"></script>
+```
+
 ## output.path
 
 - **类型：** `string`


### PR DESCRIPTION
## Summary

Add support for output.crossOriginLoading config, same as webpack：[crossOriginLoading](https://webpack.js.org/configuration/output/#outputcrossoriginloading).

Ref: https://github.com/web-infra-dev/rspack/pull/2632