### PR TITLE
fix: MenuGroup dark mode

### DIFF
--- a/theme/components/MenuGroup/index.tsx
+++ b/theme/components/MenuGroup/index.tsx
@@ -39,7 +39,7 @@ export function MenuGroup({ children, defaultLabel }: MenuGroupProps) {
         }}
       >
         <div
-          className="p-3 w-full h-full w-auto max-h-100vh rounded-xl whitespace-nowrap bg-white"
+          className="p-3 w-full h-full w-auto max-h-100vh rounded-xl whitespace-nowrap"
           style={{
             boxShadow: 'var(--modern-shadow-3)',
             marginRight: '-1.5rem',


### PR DESCRIPTION

In dark mode, the background color of MenuGroup was not displaying correctly. 
To fix this issue, I removed the tailwind CSS property bg-white from MenuGroup, allowing dark mode to work properly. 
This change does not affect any other existing features and only fixes the MenuGroup display issue in dark mode.

before:
![image](https://user-images.githubusercontent.com/45879990/230401277-ed997cbb-6ce7-4265-af94-8edae8ce9dbd.png)

after:
![image](https://user-images.githubusercontent.com/45879990/230402729-f8b24ee9-145f-4350-ac6e-503be68f45ef.png)

