### PR TITLE
fix: change valid presetEnv option

### DIFF
--- a/docs/en/guide/migrate-from-webpack.mdx
+++ b/docs/en/guide/migrate-from-webpack.mdx
@@ -49,7 +49,7 @@ Rspack also supports JavaScript syntax downgrading by default. This means you do
  module.exports = {
 +  builtins: {
 +    presetEnv: {
-+      targets: ['es5'],
++      targets: ['Chrome >= 48'],
 +    },
 +  },
 +  target: ['web', 'es5'],

--- a/docs/zh/guide/migrate-from-webpack.mdx
+++ b/docs/zh/guide/migrate-from-webpack.mdx
@@ -49,7 +49,7 @@ Rspack 已经内置了对 TypeScript、JSX 以及最新的 JavaScript 语法的�
  module.exports = {
 +  builtins: {
 +    presetEnv: {
-+      targets: ['es5'],
++      targets: ['Chrome >= 48'],
 +    },
 +  },
 +  target: ['web', 'es5'],


### PR DESCRIPTION
It seems that the `builtIn.presetEnv` option in the [migrated from webpack documentation](https://www.rspack.dev/guide/migrate-from-webpack.html) is incorrect or outdated.

The targets option only supports browserslist, but `es5` is applied.

Instead, I tried changing it to a valid option example.