### PR TITLE
Fix type checking in config examples

### DIFF
--- a/docs/en/guide/migrate-from-cra.mdx
+++ b/docs/en/guide/migrate-from-cra.mdx
@@ -27,10 +27,8 @@ First, we need to update the dependencies, uninstall all the Create React App de
 Then, we need to create the `rspack.config.js` file in the root of the project to configure rspack-related options. `@rspack/cli` does not have all the CRA functionality built-in, so some additional options need to be configured as follows
 
 ```js title=rspack.config.js
-/*
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
   entry: {
     main: './src/index.jsx', // Configure the project entry file
   },
@@ -49,6 +47,7 @@ module.exports = {
     },
   },
 };
+module.exports = config;
 ```
 
 ## migrate ejected CRA to Rspack

--- a/docs/en/guide/solid.mdx
+++ b/docs/en/guide/solid.mdx
@@ -3,10 +3,8 @@
 Thanks to the good compatibility of Rspack with the babel-loader, it is very easy to use SolidJS in rspack. All you need is babel-loader and solidjs babel preset. Rspack provides SolidJS [example](https://github.com/web-infra-dev/rspack/tree/main/examples/solid) for reference.
 
 ```js title="rspack.config.js"
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
   context: __dirname,
   entry: {
     main: './src/index.jsx',
@@ -35,4 +33,5 @@ module.exports = {
     ],
   },
 };
+module.exports = config;
 ```

--- a/docs/zh/guide/migrate-from-cra.mdx
+++ b/docs/zh/guide/migrate-from-cra.mdx
@@ -28,10 +28,9 @@
 
 ```js title=rspack.config.js
 const CopyPlugin = require('copy-webpack-plugin');
-/*
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
   entry: {
     main: './src/index.jsx', // 配置项目入口文件
   },
@@ -50,6 +49,7 @@ module.exports = {
     },
   },
 };
+module.exports = config;
 ```
 
 ## 迁移 eject 后的 CRA

--- a/docs/zh/guide/solid.mdx
+++ b/docs/zh/guide/solid.mdx
@@ -3,10 +3,8 @@
 得益于 Rspack 对 babel-loader 的良好兼容，在 Rspack 里使用 SolidJS 是非常简单的。只需要 babel-loader 配合 solidjs 的 solid-preset 即可。Rspack 提供了一个 SolidJS 的[示例](https://github.com/web-infra-dev/rspack/tree/main/examples/solid)可供参考。
 
 ```js title="rspack.config.js"
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
   context: __dirname,
   entry: {
     main: './src/index.jsx',
@@ -35,4 +33,5 @@ module.exports = {
     ],
   },
 };
+module.exports = config;
 ```

--- a/docs/zh/guide/vue.mdx
+++ b/docs/zh/guide/vue.mdx
@@ -47,10 +47,8 @@ pnpm install -D babel-loader @babel/core @vue/babel-plugin-jsx
 然后添加以下配置，即可在 `.jsx` 文件中使用 Vue 3 JSX 语法：
 
 ```js title="rspack.config.js"
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
   context: __dirname,
   entry: {
     main: './src/index.jsx',
@@ -78,6 +76,7 @@ module.exports = {
     ],
   },
 };
+module.exports = config;
 ```
 
 Rspack 提供了一个 Vue JSX 的[示例](https://github.com/web-infra-dev/rspack/tree/main/examples/vue3-jsx)可供参考。


### PR DESCRIPTION
Hi there, thanks for Rspack and the ecosystem, really cool initiative!

Quick PR to fix the type checking in the configuration file examples you have, similar to [the config page](https://www.rspack.dev/config/index.html#type-checking)

This is because of this underlying problem in TypeScript:

- https://github.com/microsoft/TypeScript/issues/47107