### PR TITLE
Revert "docs(resolve): trailing `$` in resolve.alias (#297)"

### DIFF
--- a/docs/en/config/resolve.mdx
+++ b/docs/en/config/resolve.mdx
@@ -13,17 +13,11 @@ Path alias, e.g.
 
 ```
 {
-  "@": path.resolve(__dirname, './src'),
-  // trailing `$` means exact match
-  "abc$": path.resolve(__dirname, './src/abc')
+  "@": path.resolve(__dirname, './src')
 }
 ```
 
-At this point:
-
-- `require("@/a")` will attempt to resolve `<root>/src/a`.
-- `require("abc")` will attempt to resolve `<root>/src/abc`.
-- `require("abc/file.js")` will not match, and it will attempt to resolve `node_modules/abc/file.js`.
+At this point, `require("@/a")` will attempt to resolve `<root>/src/a`.
 
 ## resolve.aliasField
 

--- a/docs/zh/config/resolve.mdx
+++ b/docs/zh/config/resolve.mdx
@@ -13,17 +13,11 @@
 
 ```
 {
-  "@": path.resolve(__dirname, './src'),
-  // 尾部的 `$` 表示精准匹配
-  "abc$": path.resolve(__dirname, './src/abc')
+  "@": path.resolve(__dirname, './src')
 }
 ```
 
-此时：
-
-- `require("@/a")` 会尝试解析 `<root>/src/a`。
-- `require("abc")` 会尝试解析 `<root>/src/abc`。
-- `require("abc/file.js")` 不会命中匹配规则，它会尝试去解析 `node_modules/abc/files.js`。
+此时，`require("@/a")` 会尝试解析 `<root>/src/a`.
 
 ## resolve.aliasField
 


### PR DESCRIPTION
This reverts commit 9305b9abb6bb6a818ea0ada3c3912546117947e1.
this will cause page crash so we revert it temporarily