### PR TITLE
style: mobile landing fix, contribution list fix

### DIFF
--- a/theme/components/Contributors.tsx
+++ b/theme/components/Contributors.tsx
@@ -3,9 +3,12 @@ import { FC } from 'react';
 export const Contributors: FC = () => (
   <>
     <hr />
-    <div className="flex flex-col my-4 items-center">
-      <div className="text-2xl mb-4">Contributors</div>
-      <object data="https://opencollective.com/rspack/contributors.svg?width=900&button=false" />
+    <div className="flex flex-col my-4 items-center overflow-x-scroll">
+      <h2 className="text-2xl mb-4">Contributors</h2>
+      <object
+        className="pl-[540px]"
+        data="https://opencollective.com/rspack/contributors.svg?width=900&button=false"
+      />
     </div>
   </>
 );

--- a/theme/components/Contributors.tsx
+++ b/theme/components/Contributors.tsx
@@ -5,10 +5,7 @@ export const Contributors: FC = () => (
     <hr />
     <div className="flex flex-col my-4 items-center overflow-x-scroll">
       <h2 className="text-2xl mb-4">Contributors</h2>
-      <object
-        className="pl-[540px]"
-        data="https://opencollective.com/rspack/contributors.svg?width=900&button=false"
-      />
+      <object data="https://opencollective.com/rspack/contributors.svg?width=900&button=false" />
     </div>
   </>
 );


### PR DESCRIPTION
Hi, 
This is a minor UI-related fix. 
I noticed on the mobile landing page, there is a horizontal scroll appearing. Resulting in a view with scrollbars on mobile (not full view format on mobile).
Also on mobile, the contributions section was overflown to the left, resulting in hidden elements in mobile view.

### Screenshots:
[Landing with a horizontal scrollbar](https://github.com/web-infra-dev/rspack-website/assets/34368503/1d35b9ad-b395-4b51-a536-23f71f0f2f10)
[Navigation menu](https://github.com/web-infra-dev/rspack-website/assets/34368503/4cb1615f-7987-4157-8524-e2dd631e2f61)

Tested browsers: iOS Safari; Chrome Desktop


### Fixes (main reason was too long width Contributions section):
-  Contributions section now has its own horizontal scrollbar (when it's too long), instead of the page's full body element.
- ~~Some elements were in Contributions overflown to the left, it is fixed~~ (object tag is not styleable as responsive).
- Contributions title changed to h2 tag, consistent with previous section headers.

### Screenshots:
[Fixed landing screenshot - full width](https://github.com/web-infra-dev/rspack-website/assets/34368503/75d92ba0-33ae-44fa-abeb-8ff7db212248)
[Fixed Navigation - full width](https://github.com/web-infra-dev/rspack-website/assets/34368503/956d0e1c-156e-462e-8ba9-33395dd992c1)



