### PR TITLE
style: Table component scroll fix

### DIFF
--- a/components/builtIns/mdx-components.tsx
+++ b/components/builtIns/mdx-components.tsx
@@ -2,10 +2,12 @@ import { ComponentProps } from 'react';
 
 export const Table = (props: ComponentProps<'table'>) => {
   return (
-    <table
-      {...props}
-      className="table border-collapse text-base my-5 overflow-x-auto leading-7 border-gray-light-2"
-    />
+    <div className="w-full overflow-x-auto">
+      <table
+        {...props}
+        className="table w-full border-collapse text-base my-5 leading-7 border-gray-light-2"
+      />
+    </div>
   );
 };
 

--- a/docs/en/api/modules.mdx
+++ b/docs/en/api/modules.mdx
@@ -8,7 +8,7 @@ While Rspack supports multiple module syntaxes, we recommend following a single 
 
 ### ES6 (Recommended)
 
-Rspack support ES6 module syntax natively, you can use static `import`、 `export` and `import()` syntax.
+Rspack support ES6 module syntax natively, you can use static `import`, `export` and `import()` syntax.
 
 ### CommonJS
 

--- a/docs/en/guide/language-support.mdx
+++ b/docs/en/guide/language-support.mdx
@@ -181,7 +181,7 @@ A "CSS Modules" file can be referenced in Rspack like this:
 In the example above, the module will be converted to a JavaScript object, which you can reference in JavaScript:
 
 ```ts title="index.js"
-import { red } from '. /index.module.css';
+import { red } from './index.module.css';
 document.getElementById('element').className = red;
 ```
 

--- a/theme/components/Contributors.tsx
+++ b/theme/components/Contributors.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 export const Contributors: FC = () => (
   <>
     <hr />
-    <div className="flex flex-col my-4 items-center overflow-x-scroll">
+    <div className="flex flex-col my-4 items-center overflow-x-auto">
       <h2 className="text-2xl mb-4">Contributors</h2>
       <object data="https://opencollective.com/rspack/contributors.svg?width=900&button=false" />
     </div>


### PR DESCRIPTION
A similar change as #353 .  (Full body, horizontal scrolling issue on mobile).
This change makes the Table (ModernTable) component responsive (scrollable) on mobile. 

#### The issue (Table is overflowing on mobile):

<img width="394" alt="Screenshot 2023-06-07 at 22 50 32" src="https://github.com/web-infra-dev/rspack-website/assets/34368503/d31871d8-ffa3-44f9-b1d7-c3990f684e7f">

#### Fix (make the Table scrollable when it overflows):
<img width="317" alt="Screenshot 2023-06-07 at 22 52 04" src="https://github.com/web-infra-dev/rspack-website/assets/34368503/46476e8d-e6eb-4616-8297-885af7220e81">

<img width="300" alt="Screenshot 2023-06-07 at 23 30 39" src="https://github.com/web-infra-dev/rspack-website/assets/34368503/3d5a8c90-5dd6-496b-a1b4-52b48ba905b7">

Tested: iOS Safari, Chrome.

### 2. Docs: small typo fix 