### PR TITLE
docs: update Nx plugin URL as @nrwl/rspack has been deprecated

### DIFF
--- a/docs/en/guide/quick-start.mdx
+++ b/docs/en/guide/quick-start.mdx
@@ -55,7 +55,7 @@ Learn more about Modern.js in the [official documentation](https://modernjs.dev/
 
 ### Using Nx
 
-The fastest way to get up to speed quickly and leverage Rspack and React in a production-ready setting is to use the dedicated [Rspack Nx plugin](https://www.npmjs.com/package/@nrwl/rspack). This gives you a pre-configured setup, integrating Rspack with React, TypeScript, ESLint, Jest, and Cypress for e2e testing.
+The fastest way to get up to speed quickly and leverage Rspack and React in a production-ready setting is to use the dedicated [Rspack Nx plugin](https://www.npmjs.com/package/@nx/rspack). This gives you a pre-configured setup, integrating Rspack with React, TypeScript, ESLint, Jest, and Cypress for e2e testing.
 
 Run the following command to set up a new Nx workspace with React and Rspack:
 
@@ -63,7 +63,7 @@ Run the following command to set up a new Nx workspace with React and Rspack:
   <Tab>
 
 ```sh
-npx create-nx-workspace myrspackapp --preset=@nrwl/rspack
+npx create-nx-workspace myrspackapp --preset=@nx/rspack
 ```
 
   </Tab>
@@ -71,7 +71,7 @@ npx create-nx-workspace myrspackapp --preset=@nrwl/rspack
   <Tab>
 
 ```sh
-yarn create nx-workspace myrspackapp --preset=@nrwl/rspack --pm=yarn
+yarn create nx-workspace myrspackapp --preset=@nx/rspack --pm=yarn
 ```
 
   </Tab>
@@ -79,7 +79,7 @@ yarn create nx-workspace myrspackapp --preset=@nrwl/rspack --pm=yarn
   <Tab>
 
 ```sh
-pnpm create nx-workspace myrspackapp --preset=@nrwl/rspack  --pm=pnpm
+pnpm create nx-workspace myrspackapp --preset=@nx/rspack  --pm=pnpm
 ```
 
   </Tab>

--- a/docs/zh/guide/quick-start.mdx
+++ b/docs/zh/guide/quick-start.mdx
@@ -55,7 +55,7 @@ Modern.js 是字节跳动 Web 工程体系的开源版本，它提供多个基�
 
 ### 使用 Nx
 
-Nx 是一个快速、可扩展的构建系统，Rspack 团队与 Nx 团队合作提供了 [Rspack Nx 插件](https://www.npmjs.com/package/@nrwl/rspack)。该插件会给你一个预设项目，将 Rspack 与 React、TypeScript、ESLint、Jest 和用于 e2e 测试的 Cypress 整合在一起，使你能迅速搭建一个用于生产环境的应用。
+Nx 是一个快速、可扩展的构建系统，Rspack 团队与 Nx 团队合作提供了 [Rspack Nx 插件](https://www.npmjs.com/package/@nx/rspack)。该插件会给你一个预设项目，将 Rspack 与 React、TypeScript、ESLint、Jest 和用于 e2e 测试的 Cypress 整合在一起，使你能迅速搭建一个用于生产环境的应用。
 
 运行以下命令，用 React 和 Rspack 建立一个新的 Nx workspace。
 
@@ -63,7 +63,7 @@ Nx 是一个快速、可扩展的构建系统，Rspack 团队与 Nx 团队合作
   <Tab>
 
 ```sh
-npx create-nx-workspace myrspackapp --preset=@nrwl/rspack
+npx create-nx-workspace myrspackapp --preset=@nx/rspack
 ```
 
   </Tab>
@@ -71,7 +71,7 @@ npx create-nx-workspace myrspackapp --preset=@nrwl/rspack
   <Tab>
 
 ```sh
-yarn create nx-workspace myrspackapp --preset=@nrwl/rspack --pm=yarn
+yarn create nx-workspace myrspackapp --preset=@nx/rspack --pm=yarn
 ```
 
   </Tab>
@@ -79,7 +79,7 @@ yarn create nx-workspace myrspackapp --preset=@nrwl/rspack --pm=yarn
   <Tab>
 
 ```sh
-pnpm create nx-workspace myrspackapp --preset=@nrwl/rspack  --pm=pnpm
+pnpm create nx-workspace myrspackapp --preset=@nx/rspack  --pm=pnpm
 ```
 
   </Tab>

--- a/project-words.txt
+++ b/project-words.txt
@@ -32,7 +32,6 @@ NAPI-RS
 nestjs
 NestJS
 nosources
-nrwl
 nwjs
 outputlibraryumdnameddefine
 recognise


### PR DESCRIPTION
Update Nx plugin URL to [@nx/rspack](https://www.npmjs.com/package/@nx/rspack) as [@nrwl/rspack](https://www.npmjs.com/package/@nrwl/rspack) has been deprecated.