### PR TITLE
Fix Issues

### DIFF
--- a/docs/en/api/loader-api.mdx
+++ b/docs/en/api/loader-api.mdx
@@ -302,7 +302,7 @@ Resolve a request.
 
 ## `this.mode`
 
-The value of [`mode`](../config/mode) is read when webpack is run.
+The value of [`mode`](/config/mode) is read when webpack is run.
 
 The possible values are: `'production'`, `'development'`, `'none'`
 

--- a/docs/zh/api/loader-api.mdx
+++ b/docs/zh/api/loader-api.mdx
@@ -301,7 +301,7 @@ config 中配置的项目所在的目录
 
 ## `this.mode`
 
-当 webpack 运行时读取 [mode](../config/mode) 的值
+当 webpack 运行时读取 [mode](/config/mode) 的值
 
 可能的值为：`'production'`、`'development'`、`'none'`
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "npx cspell --cache"
     ]
   },
-  "packageManager": "pnpm@7.32.0",
+  "packageManager": "pnpm@8.6.10",
   "dependencies": {
     "@vercel/edge": "^0.1.2",
     "date-fns": "^2.29.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tailwindcss": "^3.2.7"
   },
   "devDependencies": {
-    "@modern-js/doc-tools": "0.0.0-next-1686828255168",
+    "@modern-js/doc-tools": "2.28.0",
     "@modern-js/tsconfig": "2.21.1",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",


### PR DESCRIPTION
### Summary
+ 4509c33766f64ce902468c108f44dd7943c5dadc: Bump PNPM version in order to support nodejs v20 (https://github.com/pnpm/pnpm/issues/6424)
+ 6d09ee9567ec2bcd1f303c9b4ef46df40fb52a71: Fixes the following error on windows:
```sh
error   Internal link to /en\config/mode is dead, check it in en\api\loader-api.mdx
error   Internal link to /zh\config/mode is dead, check it in zh\api\loader-api.mdx
```
+ 6d09ee9567ec2bcd1f303c9b4ef46df40fb52a71: Fixes `The system cannot find the path specified. (os error 3)` (https://github.com/web-infra-dev/modern.js/pull/4182)

Resolves #396 