### PR TITLE
docs: mark `builtin:swc-loader` as experimental

### DIFF
--- a/docs/en/guide/loader.mdx
+++ b/docs/en/guide/loader.mdx
@@ -143,7 +143,7 @@ Built-in Loaders offer superior performance compared to JS Loaders, without sacr
 
 #### builtin:swc-loader
 
-<ApiMeta addedVersion="0.3.0" />
+<ApiMeta addedVersion="0.3.0" stability={Stability.Experimental} />
 
 `builtin:swc-loader` is the Rust version of [`swc-loader`](https://github.com/swc-project/pkgs/tree/main/packages/swc-loader), aiming to deliver better performance. The Loader's [configuration](https://swc.rs/docs/configuration/compilation) is aligned with the JS version of `swc-loader` (SWC plugins will be provided in future releases and are currently not supported).
 

--- a/docs/zh/guide/loader.mdx
+++ b/docs/zh/guide/loader.mdx
@@ -143,7 +143,7 @@ module.exports = {
 
 #### builtin:swc-loader
 
-<ApiMeta addedVersion="0.3.0" />
+<ApiMeta addedVersion="0.3.0" stability={Stability.Experimental} />
 
 `builtin:swc-loader` 是 [`swc-loader`](https://github.com/swc-project/pkgs/tree/main/packages/swc-loader) 的 Rust 版本，旨在提供更优的性能，
 Loader 的[配置](https://swc.rs/docs/configuration/compilation)与 JS 版本的 `swc-loader` 保持对齐（SWC 插件将会在未来版本进行提供，暂不支持）。


### PR DESCRIPTION
Let's mark it stable until rspack reaches 0.4.0