### PR TITLE
doc: change benchmark title from "Blazing fast build speed" to "Build Performance"

### DIFF
--- a/theme/i18n/enUS.ts
+++ b/theme/i18n/enUS.ts
@@ -12,7 +12,7 @@ export const EN_US = {
   cli: 'CLI',
   friendLink: 'Friend Link',
   community: 'Community',
-  benchmarkTitle: 'Blazing fast build speed',
+  benchmarkTitle: 'Build Performance',
   benchmarkDesc:
     'Combining TypeScript and Rust with a parallelized architecture to bring you the ultimate developer experience.',
   benchmarkDetail: 'See benchmark details',


### PR DESCRIPTION
The word "blazing" is too memey at this point, let's change it to a more "professional" titile.