### PR TITLE
fix: fix incorrect links that are linking to zh from en pages

### DIFF
--- a/docs/en/config/module.mdx
+++ b/docs/en/config/module.mdx
@@ -90,7 +90,7 @@ Matches all modules that match this resource against the Resource's query. Note:
 
 ### Rule.resourceFragment
 
-- **Type:** [`Condition`](/zh/config/module.html#condition)
+- **Type:** [`Condition`](/config/module.html#condition)
 - **Default:** `undefined`
 
 Matches all modules that match this resource against the Resource's fragment. Note: Containing `#`, when `Rule.resourceFragment` is `#abc`, it will match the resource request of `xxx#abc`
@@ -104,21 +104,21 @@ Matches all modules that match this resource, and will match against Resource (t
 
 ### Rule.issuer
 
-- **Type:** [`Condition`](/zh/config/module.html#condition)
+- **Type:** [`Condition`](/config/module.html#condition)
 - **Default:** `undefined`
 
 Matches all modules that match this resource, and will match against Resource (the absolute path without query and fragment) of the module that issued the current module.
 
 ### Rule.dependency
 
-- **Type:** [`Condition`](/zh/config/module.html#condition)
+- **Type:** [`Condition`](/config/module.html#condition)
 - **Default:** `undefined`
 
 Matches all modules that match this resource, and will match against the category of the dependency that introduced the current module, for example `esm` for `import` and `import()`, `cjs` for `require()`, `url` for `new URL()` and `url()`.
 
 ### Rule.scheme
 
-- **Type:** [`Condition`](/zh/config/module.html#condition)
+- **Type:** [`Condition`](/config/module.html#condition)
 - **Default:** `undefined`
 
 Matches all modules that match this resource, and will match against the Resource's scheme.
@@ -140,7 +140,7 @@ module.exports = {
 
 ### Rule.mimetype
 
-- **Type:** [`Condition`](/zh/config/module.html#condition)
+- **Type:** [`Condition`](/config/module.html#condition)
 - **Default:** `undefined`
 
 Matches all modules that match this resource, and will match against the Resource's mimetype.

--- a/docs/en/config/output.mdx
+++ b/docs/en/config/output.mdx
@@ -126,7 +126,7 @@ module.exports = {
 
 - **Type:** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
 
-The method to load chunks, The default value of this option depends on the [`target`](/zh/config/target.html) and [`chunkFormat`](#outputchunkformat) setting. In general, `'jsonp'` is used to load chunks when target is web; `'import'` is used to load chunks when ESM; `'import-scripts'` is used to load chunks when webworker; `'require'` is used to load chunks when node.js; `'async-node'` (`fs.readFile` + `vm.runInThisContext`) is used to load chunks when async node.js.
+The method to load chunks, The default value of this option depends on the [`target`](/config/target.html) and [`chunkFormat`](#outputchunkformat) setting. In general, `'jsonp'` is used to load chunks when target is web; `'import'` is used to load chunks when ESM; `'import-scripts'` is used to load chunks when webworker; `'require'` is used to load chunks when node.js; `'async-node'` (`fs.readFile` + `vm.runInThisContext`) is used to load chunks when async node.js.
 
 ```ts title="rspack.config.js"
 module.exports = {


### PR DESCRIPTION
I accidentally found these incorrect links.