### PR TITLE
typo: update module-resolution.mdx

### DIFF
--- a/docs/en/guide/module-resolution.mdx
+++ b/docs/en/guide/module-resolution.mdx
@@ -28,4 +28,4 @@ In this case, the directory where the resource files using import and require ar
 import 'lodash';
 ```
 
-Module paths are those that do not start with `'. /'`, `'. /'`, `'/'`. In this case, Rspack will resolve the absolute path of the module according to the module resolution rules. The [node module resolution algorithm](https://nodejs.org/api/modules.html#modules_all_together) has a detailed description of the rules for resolve modules.
+Module paths are those that do not start with `'./'`, `'../'`, `'/'`. In this case, Rspack will resolve the absolute path of the module according to the module resolution rules. The [node module resolution algorithm](https://nodejs.org/api/modules.html#modules_all_together) has a detailed description of the rules for resolve modules.


### PR DESCRIPTION
Add missing `../` and remove spaces, changes `'. /'`, `'. /'`, `'/'` to `'./'`, `'../'`, `'/'`.