### PR TITLE
Revert "docs: deprecate `builtins.devFriendlySplitChunks`"

### DIFF
--- a/docs/en/config/builtins.mdx
+++ b/docs/en/config/builtins.mdx
@@ -449,14 +449,6 @@ This configuration can be used to control progress, `false` means to turn off pr
 
 ## builtins.devFriendlySplitChunks
 
-<ApiMeta deprecatedVersion="0.3.11" />
-
-:::warning
-
-This option is deprecated, please migrate to `builtins.devFriendlySplitChunks = false` to use webpack's behavior.
-
-:::
-
 Whether to enable the development-friendly split chunks algorithm.
 
 - **Type:** `boolean`

--- a/docs/zh/config/builtins.mdx
+++ b/docs/zh/config/builtins.mdx
@@ -860,14 +860,6 @@ type BuiltinsCssModules = {
 
 ## builtins.devFriendlySplitChunks
 
-<ApiMeta deprecatedVersion="0.3.11" />
-
-:::warning
-
-配置项已经被废弃, 请迁移至 `builtins.devFriendlySplitChunks = false` 以使用 webpack 的分包行为。
-
-:::
-
 是否开启对开发友好的分包算法。
 
 - **类型：** `boolean`


### PR DESCRIPTION
Reverts web-infra-dev/rspack-website#515

Added back when v0.3.12 is released