### PR TITLE
Expand disableTransformByDefault migration docs to handle mjs/cjs

### DIFF
--- a/docs/en/blog/announcing-0.4.mdx
+++ b/docs/en/blog/announcing-0.4.mdx
@@ -74,7 +74,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /.jsx$/,
+        test: /\.jsx$/,
         loader: 'builtin:swc-loader',
         options: {
           jsc: {
@@ -112,7 +112,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /.js$/,
+        test: /\.[cm]?js$/,
         exclude: /node_modules/,
         loader: 'builtin:swc-loader',
         options: {
@@ -165,7 +165,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /.jsx$/,
+        test: /\.jsx$/,
         use: {
           loader: 'builtin:swc-loader',
           options: {

--- a/docs/en/config/experiments.mdx
+++ b/docs/en/config/experiments.mdx
@@ -126,7 +126,7 @@ Used to control whether to enable Rspack future default options, check out the d
     module: {
       rules: [
         {
-          test: /\.js$/,
+          test: /\.[cm]?js$/,
           exclude: /node_modules/,
           loader: 'builtin:swc-loader',
           options: {


### PR DESCRIPTION
In order to fully replace the default rule, mjs and cjs files must also be matched

Spawned from a [discussion in discord](https://discord.com/channels/977448667919286283/1076017776583516220/threads/1179054239352365056)