### PR TITLE
[0.5.0] docs: fix resolve.extensions format in blog post

### DIFF
--- a/docs/en/blog/announcing-0.5.mdx
+++ b/docs/en/blog/announcing-0.5.mdx
@@ -143,7 +143,7 @@ In order to get the same behavior, change `resolve.extensions` to this:
 ```js
 module.exports = {
   resolve: {
-    extensions: ['...', 'tsx', 'ts', 'jsx'], // "..." means to extend from the default extensions
+    extensions: ['...', '.tsx', '.ts', '.jsx'], // "..." means to extend from the default extensions
   },
 };
 ```

--- a/docs/zh/blog/announcing-0.5.mdx
+++ b/docs/zh/blog/announcing-0.5.mdx
@@ -143,7 +143,7 @@ module.exports = {
 ```js
 module.exports = {
   resolve: {
-    extensions: ['...', 'tsx', 'ts', 'jsx'], // "..." 代表着默认的文件扩展名。
+    extensions: ['...', '.tsx', '.ts', '.jsx'], // "..." 代表着默认的文件扩展名。
   },
 };
 ```


### PR DESCRIPTION
In the new announcement blog post extensions (that are now explicitly required) are in the wrong format. I've fixed this with this pull request.

In the regular documentation extensions are already prefixed with a `.` so everything is fine there.