### PR TITLE
docs: deprecate `resolve.browserField` and add `resolve.{preferAbsolute,restrictions,roots,aliasFields}`

### DIFF
--- a/docs/en/config/resolve.mdx
+++ b/docs/en/config/resolve.mdx
@@ -26,7 +26,18 @@ At this point:
 - `require("abc")` will attempt to resolve `<root>/src/abc`.
 - `require("abc/file.js")` will not match, and it will attempt to resolve `node_modules/abc/file.js`.
 
+## resolve.aliasFields
+
+<ApiMeta addedVersion="0.5.1" />
+
+- **Type:** `string[]`
+- **Default:** `['browser']`
+
+Define a field, such as `browser`, that should be parsed in accordance with [this specification](https://github.com/defunctzombie/package-browser-field-spec).
+
 ## resolve.browserField
+
+<ApiMeta deprecatedVersion="0.5.1" />
 
 - **Type:** `boolean`
 - **Default:** `true`
@@ -138,6 +149,15 @@ The name of the directory to use when resolving dependencies.
 
 When enabled, `require('file')` will first look for the `. /file` file in the current directory, not `<modules>/file`.
 
+## resolve.preferAbsolute
+
+<ApiMeta addedVersion="0.5.1" />
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Opt for absolute paths when resolving, in relation to `resolve.roots`.
+
 ## resolve.tsConfigPath
 
 - **Type:** `string | undefined`
@@ -210,6 +230,24 @@ This feature is disabled when the value is `undefined`.
 - **Default:** `false`
 
 No longer resolve extensions, no longer resolve mainFiles in package.json (but does not affect requests from mainFiles, browser, alias).
+
+## resolve.restrictions
+
+<ApiMeta addedVersion="0.5.1" />
+
+- **Type:** `string[]`
+- **Default:** `[]`
+
+A list of resolve restrictions to restrict the paths that a request can be resolved on.
+
+## resolve.roots
+
+<ApiMeta addedVersion="0.5.1" />
+
+- **Type:** `string[]`
+- **Default:** `[]`
+
+A list of directories where server-relative URLs (beginning with '/') are resolved. It defaults to the `context` configuration option. On systems other than Windows, these requests are initially resolved as an absolute path.
 
 ## resolve.byDependency
 

--- a/docs/zh/config/resolve.mdx
+++ b/docs/zh/config/resolve.mdx
@@ -26,7 +26,18 @@ import { ApiMeta } from '../../../components/ApiMeta';
 - `require("abc")` 会尝试解析 `<root>/src/abc`。
 - `require("abc/file.js")` 不会命中匹配规则，它会尝试去解析 `node_modules/abc/files.js`。
 
+## resolve.aliasFields
+
+<ApiMeta addedVersion="0.5.1" />
+
+- **Type:** `string[]`
+- **Default:** `['browser']`
+
+定义一个字段，例如 `browser`，以依照[此规范](https://github.com/defunctzombie/package-browser-field-spec)进行解析。
+
 ## resolve.browserField
+
+<ApiMeta deprecatedVersion="0.5.1" />
 
 - **类型：** `boolean`
 - **默认值：** `true`
@@ -138,6 +149,15 @@ module.exports = {
 
 当开启时，`require('file')` 会首先寻找当前目录下的 `./file` 文件，而不是 `<modules>/file`。
 
+## resolve.preferAbsolute
+
+<ApiMeta addedVersion="0.5.1" />
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+在解析时，倾向使用与 `resolve.roots` 相关的绝对路径。
+
 ## resolve.tsConfigPath
 
 - **类型：** `string | undefined`
@@ -210,6 +230,24 @@ module.exports = {
 - **默认值：** `false`
 
 不再解析扩展名，不再解析 package.json 中的 mainFiles（但不会影响来自 mainFiles, browser, alias 的请求）。
+
+## resolve.restrictions
+
+<ApiMeta addedVersion="0.5.1" />
+
+- **Type:** `string[]`
+- **Default:** `[]`
+
+限制请求解析路径的解析限制列表。
+
+## resolve.roots
+
+<ApiMeta addedVersion="0.5.1" />
+
+- **Type:** `string[]`
+- **Default:** `[]`
+
+一个目录列表，用于解析服务器相对 URL（以'/'开头的 URL）。默认使用 context 配置选项。在非 Windows 系统上，这些请求首先作为绝对路径进行解析。
 
 ## resolve.byDependency
 


### PR DESCRIPTION
closes #592