### PR TITLE
fix: config.devtool - missing inline-nosources-cheap-source-map

### DIFF
--- a/docs/en/config/devtool.mdx
+++ b/docs/en/config/devtool.mdx
@@ -13,6 +13,7 @@ export type Devtool =
   | 'inline-cheap-source-map'
   | 'inline-cheap-module-source-map'
   | 'inline-source-map'
+  | 'inline-nosources-cheap-source-map'
   | 'inline-nosources-cheap-module-source-map'
   | 'inline-nosources-source-map'
   | 'nosources-cheap-source-map'

--- a/docs/zh/config/devtool.mdx
+++ b/docs/zh/config/devtool.mdx
@@ -13,6 +13,7 @@ export type Devtool =
   | 'inline-cheap-source-map'
   | 'inline-cheap-module-source-map'
   | 'inline-source-map'
+  | 'inline-nosources-cheap-source-map'
   | 'inline-nosources-cheap-module-source-map'
   | 'inline-nosources-source-map'
   | 'nosources-cheap-source-map'


### PR DESCRIPTION
24 source-map options in total