### PR TITLE
fix: introduction page is broken by formatter

### DIFF
--- a/docs/en/guide/introduction.mdx
+++ b/docs/en/guide/introduction.mdx
@@ -40,13 +40,7 @@ import rspackAudio from '../../public/rspack.mp3';
   <p style={{ display: 'inline' }}>
     <span>) is a high performance Rust-based</span>
     <span>JavaScript bundler that offers strong</span>
-    <span>
-      interoperability with the{' '}
-      <a href="https://webpack.js.org/" target="_blank" rel="nofollow">
-        webpack
-      </a>{' '}
-      ecosystem,
-    </span>
+    <span>interoperability with the webpack ecosystem,</span>
     <span>enabling faster development cycles</span>
     <span>and efficient collaboration between the two tools.</span>
   </p>


### PR DESCRIPTION
Fix introduction page is broken by formatter

https://github.com/web-infra-dev/rspack-website/pull/614/files#diff-519a71e759cb55afec7cf2351843bf932d362e2750fd01d8f54158572084bb5bR43-R49