### PR TITLE
fix: remove duplicate maxInitialRequests config

### DIFF
--- a/docs/en/config/optimization-split-chunks.mdx
+++ b/docs/en/config/optimization-split-chunks.mdx
@@ -162,13 +162,6 @@ Prevents exposing path info when creating names for parts splitted by maxSize.
 
 Minimum size, in bytes, for a chunk to be generated.
 
-### splitChunks.maxInitialRequests
-
-- **Type:** `number`
-- **Default:** `20000`
-
-Minimum size, in bytes, for a chunk to be generated.
-
 ### splitChunks.maxSize
 
 `number = 0`


### PR DESCRIPTION
Remove duplicated maxInitialRequests config

fix #621