### PR TITLE
Mention `node-polyfill-webpack-plugin` in the Language Support docs

### DIFF
--- a/docs/en/guide/language-support.mdx
+++ b/docs/en/guide/language-support.mdx
@@ -44,10 +44,10 @@ See [resolve.tsConfigPath](/config/resolve#resolvetsconfigpath) for details.
 
 ### Node polyfills
 
-Rspack does not automatically inject polyfills for Node. If you need to use the corresponding functionality, add the `@rspack/plugin-node-polyfill` plugin and corresponding configuration in `rspack.config.js`:
+Rspack does not automatically inject polyfills for Node. If you need to use the corresponding functionality, add the `node-polyfill-webpack-plugin` plugin and corresponding configuration in `rspack.config.js`:
 
 ```ts title="rspack.config.js"
-const NodePolyfill = require('@rspack/plugin-node-polyfill');
+const NodePolyfill = require('node-polyfill-webpack-plugin');
 
 module.exports = {
   plugins: [new NodePolyfill()],


### PR DESCRIPTION
The docs mention `@rspack/plugin-node-polyfill` here: https://www.rspack.dev/guide/language-support#node-polyfills

However it looks like that package has now been deprecated:
- https://github.com/web-infra-dev/rspack/pull/4937
- https://github.com/web-infra-dev/rspack/tree/main/packages/rspack-plugin-node-polyfill
- https://www.npmjs.com/package/@rspack/plugin-node-polyfill

![image](https://github.com/web-infra-dev/rspack-website/assets/591645/ee47a855-a984-4444-a638-e58dbfff35be)

This PR updates the docs to reflect that change, and encourage folks to use `node-polyfill-webpack-plugin` directly.