### PR TITLE
docs: make the description of `optimization.minimizer` more clear

### DIFF
--- a/docs/en/config/optimization.mdx
+++ b/docs/en/config/optimization.mdx
@@ -75,10 +75,17 @@ If you are encountering performance issue, and you are using `optimization.split
 
 <PropertyType
   type="Array<Plugin>"
-  defaultValueList={[{ defaultValue: '[]' }]}
+  defaultValueList={[
+    {
+      defaultValue:
+        '[new SwcJsMinimizerRspackPlugin(), new SwcCssMinimizerRspackPlugin()]',
+    },
+  ]}
 />
 
-Customize the minimizer. When using a custom minimizer, the built-in minimizer will be disabled.
+Customize the minimizer. By default, [`rspack.SwcJsMinimizerRspackPlugin`](/config/plugins.html#swcjsminimizerrspackplugin)
+and [`rspack.SwcCssMinimizerRspackPlugin`](/config/plugins.html#swccssminimizerrspackplugin) are used.
+When `optimization.minimizer` is specified, the default minimizers will be disabled.
 
 ```js title=rspack.config.js
 const minifyPlugin = require('@rspack/plugin-minify');
@@ -94,6 +101,32 @@ module.exports = {
       new minifyPlugin({
         minifier: 'terser',
       }),
+    ],
+  },
+};
+```
+
+Use the built-in minimizer with custom options:
+
+```js title=rspack.config.js
+const rspack = require('@rspack/core');
+module.exports = {
+  context: __dirname,
+  target: 'node',
+  entry: {
+    main: './index.js',
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new rspack.SwcJsMinimizerRspackPlugin({
+        format: {
+          comments: false,
+        },
+      }),
+      // when `optimization.minimizer` is specified, the default minimizers are disabled
+      // so this is needed if you want to minimize css assets
+      new rspack.SwcCssMinimizerRspackPlugin(),
     ],
   },
 };

--- a/docs/en/config/optimization.mdx
+++ b/docs/en/config/optimization.mdx
@@ -111,21 +111,17 @@ Use the built-in minimizer with custom options:
 ```js title=rspack.config.js
 const rspack = require('@rspack/core');
 module.exports = {
-  context: __dirname,
-  target: 'node',
-  entry: {
-    main: './index.js',
-  },
+  // ...
   optimization: {
-    minimize: true,
+    minimize: process.env.NODE_ENV === 'production',
     minimizer: [
       new rspack.SwcJsMinimizerRspackPlugin({
         format: {
           comments: false,
         },
       }),
-      // when `optimization.minimizer` is specified, the default minimizers are disabled
-      // so this is needed if you want to minimize css assets
+      // when `optimization.minimizer` is specified, the default minimizers are disabled by default
+      // but you can use '...', it represents the default minimizers
       new rspack.SwcCssMinimizerRspackPlugin(),
     ],
   },

--- a/docs/en/config/optimization.mdx
+++ b/docs/en/config/optimization.mdx
@@ -114,14 +114,14 @@ module.exports = {
   // ...
   optimization: {
     minimize: process.env.NODE_ENV === 'production',
+    // when `optimization.minimizer` is specified, the default minimizers are disabled by default
+    // but you can use '...', it represents the default minimizers
     minimizer: [
       new rspack.SwcJsMinimizerRspackPlugin({
         format: {
           comments: false,
         },
       }),
-      // when `optimization.minimizer` is specified, the default minimizers are disabled by default
-      // but you can use '...', it represents the default minimizers
       new rspack.SwcCssMinimizerRspackPlugin(),
     ],
   },

--- a/docs/en/config/plugins.mdx
+++ b/docs/en/config/plugins.mdx
@@ -795,7 +795,7 @@ For complex HTML configuration requirements, you can use [html-webpack-plugin](h
 
 <ApiMeta addedVersion={'0.3.3'} />
 
-This plugin can be used to compress JS assets.
+This plugin can be used to compress JS assets. See [optimization.minimizer](/config/optimization.html#optimizationminimizer).
 
 ```js
 new rspack.SwcJsMinimizerRspackPlugin(options);
@@ -1032,7 +1032,7 @@ new rspack.SwcJsMinimizerRspackPlugin(options);
 
 <ApiMeta addedVersion={'0.3.3'} />
 
-This plugin can be used to compress CSS assets.
+This plugin can be used to compress CSS assets. See [optimization.minimizer](/config/optimization.html#optimizationminimizer).
 
 ```js
 new rspack.SwcCssMinimizerRspackPlugin();

--- a/docs/zh/config/optimization.mdx
+++ b/docs/zh/config/optimization.mdx
@@ -113,14 +113,14 @@ module.exports = {
   // ...
   optimization: {
     minimize: process.env.NODE_ENV === 'production',
+    // 当声明了 `optimization.minimizer`，默认压缩器会被禁用
+    // 但你可以配合使用 '...'，它代表默认压缩器
     minimizer: [
       new rspack.SwcJsMinimizerRspackPlugin({
         format: {
           comments: false,
         },
       }),
-      // 当声明了 `optimization.minimizer`，默认压缩器会被禁用
-      // 但你可以配合使用 '...'，它代表默认压缩器
       new rspack.SwcCssMinimizerRspackPlugin(),
     ],
   },

--- a/docs/zh/config/optimization.mdx
+++ b/docs/zh/config/optimization.mdx
@@ -75,10 +75,16 @@ EntryChunk2(index.js, a.js, b.js)
 
 <PropertyType.CN
   type="Array<Plugin>"
-  defaultValueList={[{ defaultValue: '[]' }]}
+  defaultValueList={[
+    {
+      defaultValue:
+        '[new SwcJsMinimizerRspackPlugin(), new SwcCssMinimizerRspackPlugin()]',
+    },
+  ]}
 />
 
-自定义压缩器。当使用自定义压缩器时，内置压缩器将会被禁用。
+自定义压缩器。默认使用 [`rspack.SwcJsMinimizerRspackPlugin`](/config/plugins.html#swcjsminimizerrspackplugin)
+和 [`rspack.SwcCssMinimizerRspackPlugin`](/config/plugins.html#swccssminimizerrspackplugin)。当声明了 `optimization.minimizer`，默认压缩器会被禁用。
 
 ```js title=rspack.config.js
 const minifyPlugin = require('@rspack/plugin-minify');
@@ -94,6 +100,32 @@ module.exports = {
       new minifyPlugin({
         minifier: 'terser',
       }),
+    ],
+  },
+};
+```
+
+使用内置压缩器和自定义选项：
+
+```js title=rspack.config.js
+const rspack = require('@rspack/core');
+module.exports = {
+  context: __dirname,
+  target: 'node',
+  entry: {
+    main: './index.js',
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new rspack.SwcJsMinimizerRspackPlugin({
+        format: {
+          comments: false,
+        },
+      }),
+      // 当声明了 `optimization.minimizer`，默认压缩器会被禁用
+      // 所以如果想压缩 CSS 资源，这一行是必要的
+      new rspack.SwcCssMinimizerRspackPlugin(),
     ],
   },
 };

--- a/docs/zh/config/optimization.mdx
+++ b/docs/zh/config/optimization.mdx
@@ -110,13 +110,9 @@ module.exports = {
 ```js title=rspack.config.js
 const rspack = require('@rspack/core');
 module.exports = {
-  context: __dirname,
-  target: 'node',
-  entry: {
-    main: './index.js',
-  },
+  // ...
   optimization: {
-    minimize: true,
+    minimize: process.env.NODE_ENV === 'production',
     minimizer: [
       new rspack.SwcJsMinimizerRspackPlugin({
         format: {
@@ -124,7 +120,7 @@ module.exports = {
         },
       }),
       // 当声明了 `optimization.minimizer`，默认压缩器会被禁用
-      // 所以如果想压缩 CSS 资源，这一行是必要的
+      // 但你可以配合使用 '...'，它代表默认压缩器
       new rspack.SwcCssMinimizerRspackPlugin(),
     ],
   },

--- a/docs/zh/config/plugins.mdx
+++ b/docs/zh/config/plugins.mdx
@@ -792,7 +792,7 @@ new rspack.HtmlRspackPlugin(options);
 
 <ApiMeta addedVersion={'0.3.3'} />
 
-此插件可以用来压缩 JS 产物。
+此插件可以用来压缩 JS 产物。参见 [optimization.minimizer](/config/optimization.html#optimizationminimizer)。
 
 ```js
 new rspack.SwcJsMinimizerRspackPlugin(options);
@@ -1029,7 +1029,7 @@ new rspack.SwcJsMinimizerRspackPlugin(options);
 
 <ApiMeta addedVersion={'0.3.3'} />
 
-此插件可以用来压缩 CSS 产物。
+此插件可以用来压缩 CSS 产物。参见 [optimization.minimizer](/config/optimization.html#optimizationminimizer)。
 
 ```js
 new rspack.SwcCssMinimizerRspackPlugin();

--- a/project-words.txt
+++ b/project-words.txt
@@ -78,6 +78,7 @@ statoscope
 suxin2017
 svgr
 swccssminimizerplugin
+swccssminimizerrspackplugin
 swcjsminimizerplugin
 swcjsminimizerrspackplugin
 swcpack


### PR DESCRIPTION
It is a bit confusing at the default value of `optimization.minimizer` and the built-in minimizer plugins should be used in `optimization.minimizer` instead of `plugins`. I make it more clear.