### PR TITLE
fix: broken mangleExports table

### DIFF
--- a/docs/zh/config/optimization.mdx
+++ b/docs/zh/config/optimization.mdx
@@ -138,8 +138,8 @@ module.exports = {
 <PropertyType.CN
   type="boolean | 'flag'"
   defaultValueList={[
-    { defaultValue: 'true', mode: '（生产模式）' },
-    { defaultValue: 'false', mode: '（开发模式）' },
+    { defaultValue: 'true', mode: 'production' },
+    { defaultValue: 'false', mode: 'development' },
   ]}
 />
 
@@ -164,7 +164,7 @@ module.exports = {
 };
 ```
 
-如果你只想使用通过（`package.json` 和 `module.rule.sideEffects`）配置的 `sideEffects`，而不想分析代码:
+如果你只想使用通过`package.json` 和 `module.rule.sideEffects` 配置的 `sideEffects`，而不想分析代码:
 
 ```js title=rspack.config.js
 module.exports = {
@@ -286,13 +286,12 @@ module.exports = {
 />
 
 `optimization.mangleExports` 允许控制导出名称的混淆。
+
 支持以下选项：
 
-| option  | description                                                          |
-| ------- | -------------------------------------------------------------------- |
-| 'named' | 使用有意义且易于调试的内容作为标识符。在开发模式下，默认启用此选项。 |
-
-| 'deterministic' | 使用哈希模块标识符作为标识符，以便从长期缓存中受益。在生产模式下，默认启用此选项。|
-| true |与 'deterministic' 相同。 |
-
-| false |保留原始名称。适用于可读性和调试。 |
+| option          | description                                                                        |
+| --------------- | ---------------------------------------------------------------------------------- |
+| 'named'         | 使用有意义且易于调试的内容作为标识符。在开发模式下，默认启用此选项。               |
+| 'deterministic' | 使用哈希模块标识符作为标识符，以便从长期缓存中受益。在生产模式下，默认启用此选项。 |
+| true            | 与 'deterministic' 相同。                                                          |
+| false           | 保留原始名称。适用于可读性和调试。                                                 |


### PR DESCRIPTION
Fix the broken mangleExports table in zh document.

<img width="705" alt="Screenshot 2024-03-19 at 17 26 34" src="https://github.com/web-infra-dev/rspack-website/assets/7237365/a88a6a39-6caf-40d6-bdcb-5cc4a0722843">
